### PR TITLE
Make the text centered

### DIFF
--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -24,6 +24,7 @@
         <item name="android:layout_marginLeft">20dp</item>
         <item name="android:layout_marginRight">20dp</item>
         <item name="android:layout_marginTop">10dp</item>
+        <item name="android:gravity">center</item>
     </style>
 
     <style name="stfButton">


### PR DESCRIPTION
Message text should be centered to make multiline messages look good.
![diff](https://cloud.githubusercontent.com/assets/8116529/25173602/67d21a32-24fd-11e7-9d4e-5ba15435c187.jpg)
